### PR TITLE
clean: 404ページのURLリンク変更

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -63,7 +63,7 @@
       <p>あなたさぁ～いい加減気づきな？</p>
       <p>存在しないページに自分がいるってことに</p>
     </div>
-    <a href="https://www.malicious-fighters.com/">トップページに戻る</a>
+    <a href="/">トップページに戻る</a>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## 概要
404ページのトップページURLリンクを現在のドメインから`/`へ変更。
ドメイン変更時の修正忘れに対応。

## チェック
404ページのトップページURLリンクからトップページへ遷移できることを確認。